### PR TITLE
Switch back to single stage build and deploy in CI pipeline

### DIFF
--- a/azure-pipelines.ci.yml
+++ b/azure-pipelines.ci.yml
@@ -14,23 +14,14 @@ trigger:
 
 pr: none
 
-stages:
-- stage: Build
-  jobs:
-  - job: Build
-    steps:
-    - template: azure-pipelines.build-template.yml
-
-- stage: Deploy
-  jobs:
-  - job: Deploy
-    steps:
-    - task: PowerShell@2
-      condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
-      displayName: 'Deploy to Firebase (only on main)'
-      inputs:
-        targetType: 'inline'
-        script: |
-          cd $(Build.Repository.LocalPath)
-          npm install firebase-tools
-          npx firebase deploy --token $(FirebaseToken)
+steps:
+- template: azure-pipelines.build-template.yml
+- task: PowerShell@2
+  condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
+  displayName: 'Deploy to Firebase (only on main)'
+  inputs:
+  targetType: 'inline'
+  script: |
+    cd $(Build.Repository.LocalPath)
+    npm install firebase-tools
+    npx firebase deploy --token $(FirebaseToken)


### PR DESCRIPTION
- To avoid overhead of publishing and downloading pipeline artifact