### PR TITLE
Switch back to single stage build and deploy in CI pipeline

### DIFF
--- a/azure-pipelines.ci.yml
+++ b/azure-pipelines.ci.yml
@@ -20,8 +20,8 @@ steps:
   condition: eq(variables['Build.SourceBranch'], 'refs/heads/main')
   displayName: 'Deploy to Firebase (only on main)'
   inputs:
-  targetType: 'inline'
-  script: |
-    cd $(Build.Repository.LocalPath)
-    npm install firebase-tools
-    npx firebase deploy --token $(FirebaseToken)
+    targetType: 'inline'
+    script: |
+      cd $(Build.Repository.LocalPath)
+      npm install firebase-tools
+      npx firebase deploy --token $(FirebaseToken)


### PR DESCRIPTION
- To avoid overhead of publishing and downloading pipeline artifact