### PR TITLE
Update BuildClient queryOrder query string parameter

### DIFF
--- a/PipelineMonitoring/Services/BuildsClient.cs
+++ b/PipelineMonitoring/Services/BuildsClient.cs
@@ -29,7 +29,7 @@ namespace PipelineMonitoring.Services
 
             var buildList = await _httpClient
                 .GetFromJsonAsync<BuildList>(
-                    $"https://dev.azure.com/{_azureDevOpsSettingsService.Organisation}/{_azureDevOpsSettingsService.Project}/_apis/build/builds?api-version=5.0&branch=master&maxBuildsPerDefinition=1")
+                    $"https://dev.azure.com/{_azureDevOpsSettingsService.Organisation}/{_azureDevOpsSettingsService.Project}/_apis/build/builds?api-version=5.0&maxBuildsPerDefinition=1&queryOrder=startTimeDescending")
                 .ConfigureAwait(false);
 
             return (filterCriteria?.ShowAll ?? false)


### PR DESCRIPTION
- As the default appears to have changed resulting in in-progress builds not being displayed
- Also remove invalid branch query string parameter